### PR TITLE
Save state to prevent lost work on page reload

### DIFF
--- a/src/app/Domain/Autosave/saveState.ts
+++ b/src/app/Domain/Autosave/saveState.ts
@@ -1,0 +1,5 @@
+export interface SaveState {
+  title: string;
+  description: string;
+  story: string;
+}

--- a/src/app/Domain/Autosave/saveState.ts
+++ b/src/app/Domain/Autosave/saveState.ts
@@ -1,7 +1,0 @@
-import { BusinessObject } from '../Common/businessObject';
-
-export interface SaveState {
-  title: string;
-  description: string;
-  domainStory: BusinessObject[];
-}

--- a/src/app/Domain/Autosave/saveState.ts
+++ b/src/app/Domain/Autosave/saveState.ts
@@ -1,5 +1,7 @@
+import { BusinessObject } from '../Common/businessObject';
+
 export interface SaveState {
   title: string;
   description: string;
-  story: string;
+  domainStory: BusinessObject[];
 }

--- a/src/app/Domain/Common/constants.ts
+++ b/src/app/Domain/Common/constants.ts
@@ -16,6 +16,7 @@ export const AUTOSAVE_INTERVAL_TAG = 'autosaveIntervalTag';
 export const AUTOSAVE_ACTIVATED_TAG = 'autosaveActivatedTag';
 export const APPENDED_ICONS_TAG = 'appendedIcons';
 export const DOMAIN_CONFIGURATION_TAG = 'domainConfigurationTag';
+export const SAVE_STATE_TAG = 'saveStateTag';
 
 /** SNACKBAR **/
 export const SNACKBAR_DURATION = 2000;

--- a/src/app/Domain/SaveState/saveState.ts
+++ b/src/app/Domain/SaveState/saveState.ts
@@ -1,0 +1,11 @@
+import { BusinessObject } from '../Common/businessObject';
+
+/**
+ * A snapshot of the current state of the application. The purpose creating a save state is to prevent work from being
+ * lost when the application is reloaded.
+ */
+export interface SaveState {
+  title: string;
+  description: string;
+  domainStory: BusinessObject[];
+}

--- a/src/app/Presentation/Canvas/modeler.component.spec.ts
+++ b/src/app/Presentation/Canvas/modeler.component.spec.ts
@@ -1,9 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import {ModelerComponent} from 'src/app/Presentation/Canvas/modeler.component';
-import { MockProvider, MockProviders } from 'ng-mocks';
+import { MockProvider } from 'ng-mocks';
 import { ModelerService } from '../../Service/Modeler/modeler.service';
 import { EMPTY } from 'rxjs';
+import { AutosaveService } from '../../Service/Autosave/autosave.service';
 
 describe('ModelerComponent', () => {
   let component: ModelerComponent;
@@ -14,7 +15,9 @@ describe('ModelerComponent', () => {
       declarations: [ModelerComponent],
       providers: [MockProvider(ModelerService, {
           getModelerUpdatedAsObservable: () => EMPTY,
-        }),],
+        }),
+        MockProvider(AutosaveService)
+      ],
     }).compileComponents();
   });
 

--- a/src/app/Presentation/Canvas/modeler.component.spec.ts
+++ b/src/app/Presentation/Canvas/modeler.component.spec.ts
@@ -1,8 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { ModelerComponent } from 'src/app/Presentation/Canvas/modeler.component';
-import { MockProviders } from 'ng-mocks';
+import {ModelerComponent} from 'src/app/Presentation/Canvas/modeler.component';
+import { MockProvider, MockProviders } from 'ng-mocks';
 import { ModelerService } from '../../Service/Modeler/modeler.service';
+import { EMPTY } from 'rxjs';
 
 describe('ModelerComponent', () => {
   let component: ModelerComponent;
@@ -11,7 +12,9 @@ describe('ModelerComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ModelerComponent],
-      providers: [MockProviders(ModelerService)],
+      providers: [MockProvider(ModelerService, {
+          getModelerUpdatedAsObservable: () => EMPTY,
+        }),],
     }).compileComponents();
   });
 

--- a/src/app/Presentation/Canvas/modeler.component.spec.ts
+++ b/src/app/Presentation/Canvas/modeler.component.spec.ts
@@ -1,10 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import {ModelerComponent} from 'src/app/Presentation/Canvas/modeler.component';
+import { ModelerComponent } from 'src/app/Presentation/Canvas/modeler.component';
 import { MockProvider } from 'ng-mocks';
 import { ModelerService } from '../../Service/Modeler/modeler.service';
 import { EMPTY } from 'rxjs';
-import { AutosaveService } from '../../Service/Autosave/autosave.service';
+import { SaveStateService } from '../../Service/SaveState/save-state.service';
 
 describe('ModelerComponent', () => {
   let component: ModelerComponent;
@@ -16,7 +16,7 @@ describe('ModelerComponent', () => {
       providers: [MockProvider(ModelerService, {
           getModelerUpdatedAsObservable: () => EMPTY,
         }),
-        MockProvider(AutosaveService)
+        MockProvider(SaveStateService)
       ],
     }).compileComponents();
   });
@@ -30,4 +30,7 @@ describe('ModelerComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  // TODO: Test creating and loading save state
+
 });

--- a/src/app/Presentation/Canvas/modeler.component.ts
+++ b/src/app/Presentation/Canvas/modeler.component.ts
@@ -21,6 +21,7 @@ export class ModelerComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.modelerService.postInit();
+    this.autosaveService.loadSaveState();
   }
 
   ngOnDestroy() {

--- a/src/app/Presentation/Canvas/modeler.component.ts
+++ b/src/app/Presentation/Canvas/modeler.component.ts
@@ -14,8 +14,7 @@ export class ModelerComponent implements OnInit, OnDestroy {
 
   constructor(private modelerService: ModelerService, private autosaveService: AutosaveService) {
     this.modelerUpdatedSubscription = this.modelerService.getModelerUpdatedAsObservable().subscribe(() => {
-      console.log('Modeler updated');
-      this.autosaveService.updateSaveState();
+      this.autosaveService.createSaveState();
     });
   }
 

--- a/src/app/Presentation/Canvas/modeler.component.ts
+++ b/src/app/Presentation/Canvas/modeler.component.ts
@@ -1,15 +1,28 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ModelerService } from '../../Service/Modeler/modeler.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-modeler',
   templateUrl: './modeler.component.html',
   styleUrls: ['./modeler.component.scss'],
 })
-export class ModelerComponent implements OnInit {
-  constructor(private modelerService: ModelerService) {}
+export class ModelerComponent implements OnInit, OnDestroy {
+
+  modelerUpdatedSubscription: Subscription;
+
+  constructor(private modelerService: ModelerService) {
+    this.modelerUpdatedSubscription = this.modelerService.modelerUpdated().subscribe(() => {
+      console.log('Modeler updated');
+    });
+  }
 
   ngOnInit(): void {
     this.modelerService.postInit();
   }
+
+  ngOnDestroy() {
+    this.modelerUpdatedSubscription.unsubscribe();
+  }
+
 }

--- a/src/app/Presentation/Canvas/modeler.component.ts
+++ b/src/app/Presentation/Canvas/modeler.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ModelerService } from '../../Service/Modeler/modeler.service';
 import { Subscription } from 'rxjs';
+import { AutosaveService } from '../../Service/Autosave/autosave.service';
 
 @Component({
   selector: 'app-modeler',
@@ -11,9 +12,10 @@ export class ModelerComponent implements OnInit, OnDestroy {
 
   modelerUpdatedSubscription: Subscription;
 
-  constructor(private modelerService: ModelerService) {
+  constructor(private modelerService: ModelerService, private autosaveService: AutosaveService) {
     this.modelerUpdatedSubscription = this.modelerService.getModelerUpdatedAsObservable().subscribe(() => {
       console.log('Modeler updated');
+      this.autosaveService.updateSaveState();
     });
   }
 

--- a/src/app/Presentation/Canvas/modeler.component.ts
+++ b/src/app/Presentation/Canvas/modeler.component.ts
@@ -2,6 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ModelerService } from '../../Service/Modeler/modeler.service';
 import { Subscription } from 'rxjs';
 import { AutosaveService } from '../../Service/Autosave/autosave.service';
+import { SaveStateService } from '../../Service/SaveState/save-state.service';
 
 @Component({
   selector: 'app-modeler',
@@ -12,15 +13,15 @@ export class ModelerComponent implements OnInit, OnDestroy {
 
   modelerUpdatedSubscription: Subscription;
 
-  constructor(private modelerService: ModelerService, private autosaveService: AutosaveService) {
+  constructor(private modelerService: ModelerService, private saveStateService: SaveStateService) {
     this.modelerUpdatedSubscription = this.modelerService.getModelerUpdatedAsObservable().subscribe(() => {
-      this.autosaveService.createSaveState();
+      this.saveStateService.createSaveState();
     });
   }
 
   ngOnInit(): void {
     this.modelerService.postInit();
-    this.autosaveService.loadSaveState();
+    this.saveStateService.loadSaveState();
   }
 
   ngOnDestroy() {

--- a/src/app/Presentation/Canvas/modeler.component.ts
+++ b/src/app/Presentation/Canvas/modeler.component.ts
@@ -12,7 +12,7 @@ export class ModelerComponent implements OnInit, OnDestroy {
   modelerUpdatedSubscription: Subscription;
 
   constructor(private modelerService: ModelerService) {
-    this.modelerUpdatedSubscription = this.modelerService.modelerUpdated().subscribe(() => {
+    this.modelerUpdatedSubscription = this.modelerService.getModelerUpdatedAsObservable().subscribe(() => {
       console.log('Modeler updated');
     });
   }

--- a/src/app/Service/Autosave/autosave.service.spec.ts
+++ b/src/app/Service/Autosave/autosave.service.spec.ts
@@ -12,7 +12,6 @@ import { deepCopy } from '../../Utils/deepCopy';
 import { BehaviorSubject } from 'rxjs';
 import { StorageService } from '../BrowserStorage/storage.service';
 import { TitleService } from '../Title/title.service';
-import { SaveState } from '../../Domain/Autosave/saveState';
 
 describe('AutosaveService', () => {
   let service: AutosaveService;
@@ -20,13 +19,11 @@ describe('AutosaveService', () => {
   let rendererServiceSpy: jasmine.SpyObj<RendererService>;
   let autosaveStateSpy: jasmine.SpyObj<AutosaveStateService>;
   let storageServiceSpy: jasmine.SpyObj<StorageService>;
-  let titleServiceSpy: jasmine.SpyObj<TitleService>;
 
   beforeEach(() => {
     const renderServiceMock = jasmine.createSpyObj('RendererService', [
       'importStory',
       'getStory',
-      'renderStory',
     ]);
     const autosaveStateServiceMock = jasmine.createSpyObj(
       'AutosaveStateService',
@@ -38,14 +35,7 @@ describe('AutosaveService', () => {
       'getAutosaves',
       'setAutosaves',
       'setMaxAutosaves',
-      'getMaxAutosaves',
-      'setSaveState',
-      'getSaveState'
-    ]);
-    const titleServiceMock = jasmine.createSpyObj('TitleService', [
-      'getTitle',
-      'getDescription',
-      'updateTitleAndDescription',
+      'getMaxAutosaves'
     ]);
 
     TestBed.configureTestingModule({
@@ -62,12 +52,8 @@ describe('AutosaveService', () => {
           provide: StorageService,
           useValue: storageServiceMock,
         },
-        {
-          provide: TitleService,
-          useValue: titleServiceMock,
-        },
-        MockProviders(DomainConfigurationService, ExportService),
-      ],
+        MockProviders(DomainConfigurationService, ExportService)
+      ]
     });
     rendererServiceSpy = TestBed.inject(
       RendererService
@@ -78,9 +64,6 @@ describe('AutosaveService', () => {
     storageServiceSpy = TestBed.inject(
       StorageService
     ) as jasmine.SpyObj<StorageService>;
-    titleServiceSpy = TestBed.inject(
-      TitleService
-    ) as jasmine.SpyObj<TitleService>;
 
     autosaveStateSpy.getAutosaveStateAsObservable.and.returnValue(
       new BehaviorSubject(false).asObservable()
@@ -174,57 +157,5 @@ describe('AutosaveService', () => {
       date,
     };
   }
-
-  describe('createSaveState', () => {
-
-    it('should set title and description from title service', () => {
-      titleServiceSpy.getTitle.and.returnValue('test title');
-      titleServiceSpy.getDescription.and.returnValue('test description');
-      const saveState = service.createSaveState();
-
-      expect(titleServiceSpy.getTitle).toHaveBeenCalled();
-      expect(titleServiceSpy.getDescription).toHaveBeenCalled();
-      expect(saveState.title).toEqual('test title');
-      expect(saveState.description).toEqual('test description');
-    });
-
-    it('should set domain story from renderer service', () => {
-
-    });
-  });
-
-  describe('loadSaveState', () => {
-    const saveState: SaveState = {
-      title: 'test title',
-      description: 'test description',
-      domainStory: []
-    };
-
-    beforeEach(() => {
-      storageServiceSpy.getSaveState.and.returnValue(saveState);
-    });
-
-    it('should getSaveState from local Storage', () => {
-      const loadedSaveState = service.loadSaveState();
-
-      expect(storageServiceSpy.getSaveState).toHaveBeenCalled();
-      expect(loadedSaveState).toEqual(saveState);
-    });
-
-    it('should call titleService.updateTitleAndDescription', () => {
-      service.loadSaveState();
-
-      expect(titleServiceSpy.updateTitleAndDescription)
-        .toHaveBeenCalledWith(saveState.title, saveState.description, false);
-    });
-
-    it('should call rendererService.renderStory', () => {
-      service.loadSaveState();
-
-      expect(rendererServiceSpy.renderStory).toHaveBeenCalledWith(saveState.domainStory);
-    });
-
-  });
-
 
 });

--- a/src/app/Service/Autosave/autosave.service.ts
+++ b/src/app/Service/Autosave/autosave.service.ts
@@ -87,9 +87,16 @@ export class AutosaveService {
   public updateSaveState(): void {
     const title = this.exportService.title;
     const description = this.exportService.description;
-    const story = JSON.stringify(this.rendererService.getStory());
+    const domainStory = this.rendererService.getStory();
 
-    this.storageService.setSaveState({title, description, story: story});
+    this.storageService.setSaveState({title, description, domainStory});
+  }
+
+  public loadSaveState() {
+    const saveState = this.storageService.getSaveState();
+    if (saveState) {
+      this.rendererService.renderStory(saveState.domainStory)
+    }
   }
 
   private createAutosave(): Autosave {

--- a/src/app/Service/Autosave/autosave.service.ts
+++ b/src/app/Service/Autosave/autosave.service.ts
@@ -84,6 +84,14 @@ export class AutosaveService {
     return this.autosaveEnabled;
   }
 
+  public updateSaveState(): void {
+    const title = this.exportService.title;
+    const description = this.exportService.description;
+    const story = JSON.stringify(this.rendererService.getStory());
+
+    this.storageService.setSaveState({title, description, story: story});
+  }
+
   private createAutosave(): Autosave {
     const dst = JSON.stringify(this.rendererService.getStory(), null, 2);
     const configAndDST = this.exportService.createConfigAndDST(dst);

--- a/src/app/Service/Autosave/autosave.service.ts
+++ b/src/app/Service/Autosave/autosave.service.ts
@@ -10,6 +10,7 @@ import { elementTypes } from '../../Domain/Common/elementTypes';
 import { fromConfigurationFromFile } from '../../Domain/Common/domainConfiguration';
 import { StorageService } from '../BrowserStorage/storage.service';
 import { TitleService } from '../Title/title.service';
+import { SaveState } from '../../Domain/Autosave/saveState';
 
 @Injectable({
   providedIn: 'root',
@@ -86,19 +87,24 @@ export class AutosaveService {
     return this.autosaveEnabled;
   }
 
-  public updateSaveState(): void {
-    const title = this.titleService.getTitle();
-    const description = this.titleService.getDescription();
-    const domainStory = this.rendererService.getStory();
-    this.storageService.setSaveState({title, description, domainStory});
+  public createSaveState(): SaveState {
+    const saveState = {
+      title: this.titleService.getTitle(),
+      description: this.titleService.getDescription(),
+      domainStory: this.rendererService.getStory()
+    }
+    this.storageService.setSaveState(saveState);
+    return saveState;
   }
 
-  public loadSaveState() {
+  public loadSaveState(): SaveState | undefined {
     const saveState = this.storageService.getSaveState();
     if (saveState) {
       this.titleService.updateTitleAndDescription(saveState.title, saveState.description, false);
       this.rendererService.renderStory(saveState.domainStory)
+      return saveState;
     }
+    return;
   }
 
   private createAutosave(): Autosave {

--- a/src/app/Service/Autosave/autosave.service.ts
+++ b/src/app/Service/Autosave/autosave.service.ts
@@ -9,6 +9,7 @@ import { IconDictionaryService } from '../DomainConfiguration/icon-dictionary.se
 import { elementTypes } from '../../Domain/Common/elementTypes';
 import { fromConfigurationFromFile } from '../../Domain/Common/domainConfiguration';
 import { StorageService } from '../BrowserStorage/storage.service';
+import { TitleService } from '../Title/title.service';
 
 @Injectable({
   providedIn: 'root',
@@ -25,7 +26,8 @@ export class AutosaveService {
     private exportService: ExportService,
     private autosaveStateService: AutosaveStateService,
     private iconDistionaryService: IconDictionaryService,
-    private storageService: StorageService
+    private storageService: StorageService,
+    private titleService: TitleService,
   ) {
     this.maxAutosaves = storageService.getMaxAutosaves();
     this.autosaveEnabled =
@@ -85,16 +87,16 @@ export class AutosaveService {
   }
 
   public updateSaveState(): void {
-    const title = this.exportService.title;
-    const description = this.exportService.description;
+    const title = this.titleService.getTitle();
+    const description = this.titleService.getDescription();
     const domainStory = this.rendererService.getStory();
-
     this.storageService.setSaveState({title, description, domainStory});
   }
 
   public loadSaveState() {
     const saveState = this.storageService.getSaveState();
     if (saveState) {
+      this.titleService.updateTitleAndDescription(saveState.title, saveState.description, false);
       this.rendererService.renderStory(saveState.domainStory)
     }
   }

--- a/src/app/Service/Autosave/autosave.service.ts
+++ b/src/app/Service/Autosave/autosave.service.ts
@@ -9,8 +9,6 @@ import { IconDictionaryService } from '../DomainConfiguration/icon-dictionary.se
 import { elementTypes } from '../../Domain/Common/elementTypes';
 import { fromConfigurationFromFile } from '../../Domain/Common/domainConfiguration';
 import { StorageService } from '../BrowserStorage/storage.service';
-import { TitleService } from '../Title/title.service';
-import { SaveState } from '../../Domain/Autosave/saveState';
 
 @Injectable({
   providedIn: 'root',
@@ -27,8 +25,7 @@ export class AutosaveService {
     private exportService: ExportService,
     private autosaveStateService: AutosaveStateService,
     private iconDistionaryService: IconDictionaryService,
-    private storageService: StorageService,
-    private titleService: TitleService,
+    private storageService: StorageService
   ) {
     this.maxAutosaves = storageService.getMaxAutosaves();
     this.autosaveEnabled =
@@ -87,26 +84,6 @@ export class AutosaveService {
     return this.autosaveEnabled;
   }
 
-  public createSaveState(): SaveState {
-    const saveState = {
-      title: this.titleService.getTitle(),
-      description: this.titleService.getDescription(),
-      domainStory: this.rendererService.getStory()
-    }
-    this.storageService.setSaveState(saveState);
-    return saveState;
-  }
-
-  public loadSaveState(): SaveState | undefined {
-    const saveState = this.storageService.getSaveState();
-    if (saveState) {
-      this.titleService.updateTitleAndDescription(saveState.title, saveState.description, false);
-      this.rendererService.renderStory(saveState.domainStory)
-      return saveState;
-    }
-    return;
-  }
-
   private createAutosave(): Autosave {
     const dst = JSON.stringify(this.rendererService.getStory(), null, 2);
     const configAndDST = this.exportService.createConfigAndDST(dst);
@@ -143,6 +120,7 @@ export class AutosaveService {
       this.storageService.setAutosaves(currentAutosaves);
     }, this.autosaveInterval.getValue() * 60000);
   }
+
   public loadCurrentAutosaves(): Autosave[] {
     const autosaves = this.storageService.getAutosaves();
     this.sortAutosaves(autosaves);

--- a/src/app/Service/BrowserStorage/storage.service.ts
+++ b/src/app/Service/BrowserStorage/storage.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import {
+  SAVE_STATE_TAG,
   AUTOSAVE_ACTIVATED_TAG,
   AUTOSAVE_AMOUNT_TAG,
   AUTOSAVE_INTERVAL_TAG,
@@ -13,6 +14,7 @@ import {
   DomainConfiguration,
   fromConfigurationFromFile,
 } from '../../Domain/Common/domainConfiguration';
+import { SaveState } from '../../Domain/Autosave/saveState';
 
 @Injectable({
   providedIn: 'root',
@@ -114,4 +116,9 @@ export class StorageService {
       JSON.stringify(configForStorage, null, 2)
     );
   }
+
+  setSaveState(saveState: SaveState) {
+    localStorage.setItem(SAVE_STATE_TAG, JSON.stringify(saveState));
+  }
+
 }

--- a/src/app/Service/BrowserStorage/storage.service.ts
+++ b/src/app/Service/BrowserStorage/storage.service.ts
@@ -121,4 +121,12 @@ export class StorageService {
     localStorage.setItem(SAVE_STATE_TAG, JSON.stringify(saveState));
   }
 
+  getSaveState(): SaveState | undefined {
+    const saveStateString = localStorage.getItem(SAVE_STATE_TAG);
+    if (saveStateString) {
+      return JSON.parse(saveStateString);
+    }
+    return;
+  }
+
 }

--- a/src/app/Service/BrowserStorage/storage.service.ts
+++ b/src/app/Service/BrowserStorage/storage.service.ts
@@ -14,7 +14,7 @@ import {
   DomainConfiguration,
   fromConfigurationFromFile,
 } from '../../Domain/Common/domainConfiguration';
-import { SaveState } from '../../Domain/Autosave/saveState';
+import { SaveState } from '../../Domain/SaveState/saveState';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/Service/Modeler/modeler.service.ts
+++ b/src/app/Service/Modeler/modeler.service.ts
@@ -37,10 +37,10 @@ export class ModelerService {
   /**
    * Emits an event every time the domain story or title/description is updated.
    */
-  private modelerUpdated$ = new Subject();
+  private modelerUpdated = new Subject();
 
-  public modelerUpdated(): Observable<any> {
-    return this.modelerUpdated$.asObservable();
+  public getModelerUpdatedAsObservable(): Observable<any> {
+    return this.modelerUpdated.asObservable();
   }
 
   public postInit(): void {
@@ -160,7 +160,7 @@ export class ModelerService {
         // tslint:disable-next-line:no-unused-expression
         fn(this.modeler).then((svg: string) => {
           this.encoded = svg;
-          this.modelerUpdated$.next()
+          this.modelerUpdated.next()
         }) as Promise<any>;
       }, timeout);
     };

--- a/src/app/Service/Modeler/modeler.service.ts
+++ b/src/app/Service/Modeler/modeler.service.ts
@@ -11,6 +11,7 @@ import { IconDictionaryService } from '../DomainConfiguration/icon-dictionary.se
 import { DomainConfigurationService } from '../DomainConfiguration/domain-configuration.service';
 import { BusinessObject } from '../../Domain/Common/businessObject';
 import { StorageService } from '../BrowserStorage/storage.service';
+import { Observable, Subject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -32,6 +33,15 @@ export class ModelerService {
   private eventBus: any;
 
   private encoded: string | undefined;
+
+  /**
+   * Emits an event every time the domain story or title/description is updated.
+   */
+  private modelerUpdated$ = new Subject();
+
+  public modelerUpdated(): Observable<any> {
+    return this.modelerUpdated$.asObservable();
+  }
 
   public postInit(): void {
     const storedDomainConfiguration =
@@ -150,6 +160,7 @@ export class ModelerService {
         // tslint:disable-next-line:no-unused-expression
         fn(this.modeler).then((svg: string) => {
           this.encoded = svg;
+          this.modelerUpdated$.next()
         }) as Promise<any>;
       }, timeout);
     };

--- a/src/app/Service/SaveState/save-state.service.spec.ts
+++ b/src/app/Service/SaveState/save-state.service.spec.ts
@@ -1,0 +1,121 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SaveStateService } from './save-state.service';
+import { StorageService } from '../BrowserStorage/storage.service';
+import { TitleService } from '../Title/title.service';
+import { RendererService } from '../Renderer/renderer.service';
+import { SaveState } from '../../Domain/SaveState/saveState';
+import { testBusinessObject } from '../../Domain/Common/businessObject';
+
+describe('SaveStateService', () => {
+  let service: SaveStateService;
+
+  let rendererServiceSpy: jasmine.SpyObj<RendererService>;
+  let storageServiceSpy: jasmine.SpyObj<StorageService>;
+  let titleServiceSpy: jasmine.SpyObj<TitleService>;
+
+  beforeEach(() => {
+    const renderServiceMock = jasmine.createSpyObj('RendererService', [
+      'importStory',
+      'getStory',
+      'renderStory',
+    ]);
+    const storageServiceMock = jasmine.createSpyObj('StorageService', [
+      'setSaveState',
+      'getSaveState'
+    ]);
+    const titleServiceMock = jasmine.createSpyObj('TitleService', [
+      'getTitle',
+      'getDescription',
+      'updateTitleAndDescription',
+    ]);
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: RendererService,
+          useValue: renderServiceMock,
+        },
+        {
+          provide: StorageService,
+          useValue: storageServiceMock,
+        },
+        {
+          provide: TitleService,
+          useValue: titleServiceMock,
+        },
+      ]
+    });
+    rendererServiceSpy = TestBed.inject(
+      RendererService
+    ) as jasmine.SpyObj<RendererService>;
+    storageServiceSpy = TestBed.inject(
+      StorageService
+    ) as jasmine.SpyObj<StorageService>;
+    titleServiceSpy = TestBed.inject(
+      TitleService
+    ) as jasmine.SpyObj<TitleService>;
+
+
+    service = TestBed.inject(SaveStateService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('createSaveState', () => {
+
+    it('should set title and description from title service', () => {
+      titleServiceSpy.getTitle.and.returnValue('test title');
+      titleServiceSpy.getDescription.and.returnValue('test description');
+      const saveState = service.createSaveState();
+
+      expect(titleServiceSpy.getTitle).toHaveBeenCalled();
+      expect(titleServiceSpy.getDescription).toHaveBeenCalled();
+      expect(saveState.title).toEqual('test title');
+      expect(saveState.description).toEqual('test description');
+    });
+
+    it('should load domain story from renderer service', () => {
+      rendererServiceSpy.getStory.and.returnValue([testBusinessObject])
+      const saveState = service.createSaveState();
+
+      expect(rendererServiceSpy.getStory).toHaveBeenCalled();
+      expect(saveState.domainStory).toEqual([testBusinessObject]);
+    });
+  });
+
+  describe('loadSaveState', () => {
+    const saveState: SaveState = {
+      title: 'test title',
+      description: 'test description',
+      domainStory: []
+    };
+
+    beforeEach(() => {
+      storageServiceSpy.getSaveState.and.returnValue(saveState);
+    });
+
+    it('should getSaveState from local Storage', () => {
+      const loadedSaveState = service.loadSaveState();
+
+      expect(storageServiceSpy.getSaveState).toHaveBeenCalled();
+      expect(loadedSaveState).toEqual(saveState);
+    });
+
+    it('should call titleService.updateTitleAndDescription', () => {
+      service.loadSaveState();
+
+      expect(titleServiceSpy.updateTitleAndDescription)
+        .toHaveBeenCalledWith(saveState.title, saveState.description, false);
+    });
+
+    it('should call rendererService.renderStory', () => {
+      service.loadSaveState();
+
+      expect(rendererServiceSpy.renderStory).toHaveBeenCalledWith(saveState.domainStory);
+    });
+
+  });
+
+});

--- a/src/app/Service/SaveState/save-state.service.ts
+++ b/src/app/Service/SaveState/save-state.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+import { StorageService } from '../BrowserStorage/storage.service';
+import { RendererService } from '../Renderer/renderer.service';
+import { TitleService } from '../Title/title.service';
+import { SaveState } from '../../Domain/SaveState/saveState';
+
+/**
+ * A service for creating and loading the current state of the application.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class SaveStateService {
+
+  constructor(
+    private rendererService: RendererService,
+    private storageService: StorageService,
+    private titleService: TitleService
+  ) {
+  }
+
+  /**
+   * Saves the current state.
+   */
+  public createSaveState(): SaveState {
+    const saveState = {
+      title: this.titleService.getTitle(),
+      description: this.titleService.getDescription(),
+      domainStory: this.rendererService.getStory()
+    }
+    this.storageService.setSaveState(saveState);
+    return saveState;
+  }
+
+  /**
+   * Loads and renders the last saved state.
+   */
+  public loadSaveState(): SaveState | undefined {
+    const saveState = this.storageService.getSaveState();
+    if (saveState) {
+      this.titleService.updateTitleAndDescription(saveState.title, saveState.description, false);
+      this.rendererService.renderStory(saveState.domainStory)
+      return saveState;
+    }
+    return;
+  }
+
+}


### PR DESCRIPTION
I have introduced a new concept into the domain called "SaveState", with a service for creating and loading the current state of the application. The purpose for this is to prevent work from being lost when the application is reloaded ( see #110 ).

I have done my best to avoid conflicting this with the existing "Autosave". What I have created wouldn't require enabling or setting the save interval, max saves, etc. Thinking about this more, I imagine the current "Autosave" to then be more like a "Backup save" that would allow the user to revert back to a previous save state. If this PR gets merged then perhaps Autosave would be refactored to have a SaveState property for storing the title, description, and story and a separate property for the domain config rather than the single "ConfigAndDST" that it has now.

I have included tests, and made sure I didn't break the existing tests. The two test failures from SvgService and AppComponent were present before this PR. I also noticed that importing a story can cause errors and break things, but again I believe that is unrelated to this PR.